### PR TITLE
Dockerize project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG NODE_VERSION
+
+FROM node:${NODE_VERSION} AS build
+
+RUN mkdir /app
+
+COPY . /app
+
+WORKDIR /app
+
+RUN yarn install \
+  --frozen-lockfile \
+  --no-optional \
+  --production
+
+FROM node:${NODE_VERSION}
+WORKDIR /app
+COPY --from=build /app /app
+
+ENTRYPOINT ["yarn", "start"]
+


### PR DESCRIPTION
Closes #17 

To build run:
`docker build --build-arg NODE_VERSION=12.18.2 -t spookybot:latest .`

Currently, blocked by #19, otherwise `docker run spookybot:latest` would work