### PR TITLE
Feature/scare queue

### DIFF
--- a/commands/Sound/playsound.js
+++ b/commands/Sound/playsound.js
@@ -12,7 +12,7 @@ module.exports = {
     displayHelp: false,
   },
 
-  run: async (bot, message, args) => {
+  run: async (bot, message, args, callback) => {
     if (message.member.voice.channel) {
       let soundPath = __dirname + `/../../sounds/`
       const connection = await message.member.voice.channel.join()
@@ -25,6 +25,7 @@ module.exports = {
 
       dispatcher.on('finish', () => {
         connection.voice.channel.leave()
+        callback()
       })
     } else {
       message.reply('How can I scare your companions without you beeing present in the voice channel?')

--- a/events/message.js
+++ b/events/message.js
@@ -32,6 +32,7 @@ module.exports = async (bot, webhook, message) => {
     // Our standard argument/command name definition.
     const args = message.content.slice(prefix.length).trim().split(/ +/g)
     const command = args.shift().toLowerCase()
+
     // Grab the command data from the client Collection
     const cmd = bot.commands.get(command) || bot.commands.get(bot.aliases.get(command))
 
@@ -47,6 +48,7 @@ module.exports = async (bot, webhook, message) => {
     webhook.send(privateEmbed)
 
     // -------------------- Command execution --------------------
+
     message.delete()
     if (!message.member.hasPermission(cmd.config.permissionNeeded)) {
       message.reply('Only your server administrator can do this!').then((m) => {

--- a/events/message.js
+++ b/events/message.js
@@ -6,22 +6,19 @@ const reactMessage = require('../utils/reactMessage')
 cmdQueue = []
 handlingCommand = false
 
-var done = function() {
-    handlingCommand = false
-}
-
 var waitToRunCommand = function() {
-  if (handlingCommand) {
-    setTimeout(waitToRunCommand, 300) 
-  } else {
-    setTimeout(runCommand, 300) 
-  }
+  setTimeout(runCommand, 300) 
 }
 
 var runCommand = function() {
   handlingCommand = true
   const cmdFunc = cmdQueue.shift()
   cmdFunc.cmd.run(cmdFunc.bot, cmdFunc.message, cmdFunc.args, done)
+}
+
+var done = function() {
+    handlingCommand = false
+    if (cmdQueue.length > 0) waitToRunCommand()
 }
 
 module.exports = async (bot, webhook, message) => {
@@ -61,7 +58,9 @@ module.exports = async (bot, webhook, message) => {
     }
     // ----- Push to queue and wait for other jobs to finish -----
     cmdQueue.push({cmd: cmd, bot: bot, message: message, args: args})
-    waitToRunCommand()
+    if (!handlingCommand) {
+      waitToRunCommand()
+    }
   } else {
     // -------------------- Reaction system --------------------
     reactMessage(message.guild.id, message)


### PR DESCRIPTION
Closes #34 

This allows multiple scare commands to be sent while a scare command is currently being processed.

If a scare command is being processed, other commands that come in get put in a queue, and the first event handler keeps running until the queue is empty.

Note: the waitToRunCommand function is there, because the bot was having issues leaving the voice channel and entering again immediately, so I put that in to buffer it each time that happens.